### PR TITLE
Add GitLab CI deployment example

### DIFF
--- a/.github/workflows/k8s_deploy.yml
+++ b/.github/workflows/k8s_deploy.yml
@@ -1,0 +1,28 @@
+name: Kubernetes Deployment
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v3
+        with:
+          version: 'v1.27.1'
+
+      - name: Configure kubeconfig
+        run: |
+          mkdir -p $HOME/.kube
+          echo "${{ secrets.KUBE_CONFIG }}" | base64 --decode > $HOME/.kube/config
+          chmod 600 $HOME/.kube/config
+
+      - name: Deploy manifests
+        run: kubectl apply -f k8s/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,14 @@
+image: bitnami/kubectl:1.27
+
+stages:
+  - deploy
+
+deploy_to_k8s:
+  stage: deploy
+  script:
+    - mkdir -p ~/.kube
+    - echo "$KUBE_CONFIG" | base64 -d > ~/.kube/config
+    - chmod 600 ~/.kube/config
+    - kubectl apply -f k8s/
+  only:
+    - master

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Kubernetes Deployment Example
+
+This repository demonstrates a simple Kubernetes deployment using GitLab CI/CD.
+The pipeline expects a base64 encoded kubeconfig in the `KUBE_CONFIG` CI/CD
+variable. A self-hosted GitLab Runner executes the job and applies the manifests
+found in the `k8s/` directory.
+
+1. Build your Docker image in the BMC repository or another project.
+2. Push the image to your container registry.
+3. Update `k8s/deployment.yaml` with the new image reference.
+4. Commit and push the changes to run the deployment pipeline.
+
+The provided `.gitlab-ci.yml` defines a single `deploy` job that configures
+kubectl and applies the manifests to your EKS cluster.

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sample-nginx
+spec:
+  selector:
+    matchLabels:
+      app: sample-nginx
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: sample-nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:stable
+          ports:
+            - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sample-nginx
+spec:
+  selector:
+    app: sample-nginx
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80


### PR DESCRIPTION
## Summary
- add README with GitLab usage instructions
- provide `.gitlab-ci.yml` to deploy manifests using kubectl

## Testing
- `git status --short`