### PR TITLE
Disable persistence for Elasticsearch data and master configurations

### DIFF
--- a/deploy-as-code/helm/charts/backbone-services/elasticsearch/elasticsearch-data-v1-values.yaml
+++ b/deploy-as-code/helm/charts/backbone-services/elasticsearch/elasticsearch-data-v1-values.yaml
@@ -134,7 +134,7 @@ podSecurityPolicy:
       - persistentVolumeClaim
 
 persistence:
-  enabled: true
+  enabled: false
   dataDirSize: "25Gi"
   annotations: {}
 

--- a/deploy-as-code/helm/charts/backbone-services/elasticsearch/elasticsearch-master-v1-values.yaml
+++ b/deploy-as-code/helm/charts/backbone-services/elasticsearch/elasticsearch-master-v1-values.yaml
@@ -132,7 +132,7 @@ podSecurityPolicy:
       - persistentVolumeClaim
 
 persistence:
-  enabled: true
+  enabled: false
   dataDirSize: "2Gi"
   annotations: {}
 


### PR DESCRIPTION
Since you're running on k3d (local development), the best approach is to disable manual PV creation and use K3d's built-in dynamic storage provisioning. This is simpler and works automatically.